### PR TITLE
Add: macros for engine

### DIFF
--- a/src/nn.rs
+++ b/src/nn.rs
@@ -48,7 +48,6 @@ impl<const P: usize, const N: usize> Debug for Layer<P, N> {
             match self.nonlin {
                 Activations::Relu => "ReLU",
                 Activations::Tanh => "Tanh",
-                Activations::Softmax => "Softmax",
                 Activations::Linear => "Linear",
             },
             N


### PR DESCRIPTION
This should be the last PR to v2. we want to simplify the boilerplate used and make our engine.rs easier to read. 

We should be able to use the same logic when we go to matrix operations instead of scalar operations